### PR TITLE
Set BUZZER_PIN to output only before actually buzzing

### DIFF
--- a/H101_dual/src/config.h
+++ b/H101_dual/src/config.h
@@ -235,6 +235,7 @@
 // uncomment to enable buzzer
 //#define BUZZER_ENABLE
 
+//#define BUZZER_PIN       GPIO_PIN_13 // SWDAT
 #define BUZZER_PIN       GPIO_PIN_14 // SWCLK
 #define BUZZER_PIN_PORT  GPIOA
 #define BUZZER_DELAY     5000000 // 5 seconds after loss of tx or low bat before buzzer starts

--- a/H101_dual/src/main.c
+++ b/H101_dual/src/main.c
@@ -31,13 +31,13 @@ THE SOFTWARE.
 
 #include "gd32f1x0.h"
 
+#include "config.h"
 #include "led.h"
 #include "util.h"
 #include "sixaxis.h"
 #include "drv_adc.h"
 #include "drv_time.h"
 #include "drv_softi2c.h"
-#include "config.h"
 #include "drv_pwm.h"
 #include "drv_adc.h"
 #include "drv_gpio.h"
@@ -307,14 +307,19 @@ vbatt = battadc;
 			if (rxmode == RX_MODE_BIND)
 				buzzer_delay = 20000000;
 
-			if (!buzzer_init && maintime > buzzer_delay) 
+			if (maintime > buzzer_delay)
 			{
-				if (gpio_init_buzzer())
-					buzzer_init = 1;
-			}
-			else if (buzzer_init && maintime > buzzer_delay)
-			{
-				buzzer();
+				if (lowbatt || failsafe || buzzer_init)
+				{
+					if (!buzzer_init)
+					{
+						buzzer_init = gpio_init_buzzer();
+					}
+					else
+					{
+						buzzer();
+					}
+				}
 			}
 #endif
 


### PR DESCRIPTION
...as shown by bikemikem here: http://www.rcgroups.com/forums/showpost.php?p=35632071&postcount=4702

Also fixed compiler warning by reordering includes.
