### PR TITLE
Set PWM to 0 during BRIDGE_WAIT

### DIFF
--- a/H101_dual/src/control.c
+++ b/H101_dual/src/control.c
@@ -677,7 +677,11 @@ if ( excess_ratio < 0.0f ) excess_ratio = 0.0;
 					
 					#ifndef NOMOTORS
 					//normal mode
-					pwm_set( i , test );	
+					if (bridge_stage == BRIDGE_WAIT) {
+						pwm_set( i , 0 );
+					} else {
+						pwm_set( i , test );
+					}
 					#else
 					#warning "NO MOTORS"
 					#endif

--- a/H101_dual/src/drv_pwm.c
+++ b/H101_dual/src/drv_pwm.c
@@ -329,11 +329,11 @@ void motorbeep( void)
 void pwm_set(uint8_t number, float pwm)
 {
 
-	if (pwmdir == DIR1)
+	if (pwmdir == REVERSE)
 	  {
 		  pwm_set_reverse(number, pwm);
 	  }
-	if (pwmdir == DIR2)
+	if (pwmdir == FORWARD)
 	  {
 		  pwm_set_forward(number, pwm);
 	  }
@@ -420,22 +420,24 @@ void pwm_set_reverse(uint8_t number, float pwm)
 
 void pwm_dir(int dir)
 {
-	if (dir == DIR2)
+	if (dir == FORWARD)
 	  {
-		  pwmdir = DIR2;
+		  pwmdir = FORWARD;
 		  for (int i = 0; i <= 3; i++)
 			  pwm_set_reverse(i, 0.0f);
-		  GPIO_WriteBit(GPIOF, GPIO_PIN_1, Bit_SET);	// bridge dir 1      
 		  GPIO_WriteBit(GPIOA, GPIO_PIN_4, Bit_RESET);	// bridge dir 2
+		  delay(1000);
+		  GPIO_WriteBit(GPIOF, GPIO_PIN_1, Bit_SET);	// bridge dir 1
 
 	  }
 
-	if (dir == DIR1)
+	if (dir == REVERSE)
 	  {
-		  pwmdir = DIR1;
+		  pwmdir = REVERSE;
 		  for (int i = 0; i <= 3; i++)
 			  pwm_set_forward(i, 0.0f);
 		  GPIO_WriteBit(GPIOF, GPIO_PIN_1, Bit_RESET);	// bridge dir 1
+		  delay(1000);
 		  GPIO_WriteBit(GPIOA, GPIO_PIN_4, Bit_SET);	// bridge dir 2
 	  }
 	if (dir == FREE)
@@ -445,7 +447,7 @@ void pwm_dir(int dir)
 			    pwm_set_reverse(i, 0.0f);
 			    pwm_set_forward(i, 0.0f);
 		    }
-		  GPIO_WriteBit(GPIOF, GPIO_PIN_1, Bit_RESET);	// bridge dir 1    
+		  GPIO_WriteBit(GPIOF, GPIO_PIN_1, Bit_RESET);	// bridge dir 1
 		  GPIO_WriteBit(GPIOA, GPIO_PIN_4, Bit_RESET);	// bridge dir 2
 	  }
 	if (dir == BRAKE)
@@ -456,8 +458,8 @@ void pwm_dir(int dir)
 		     pwm_set_forward( i , 0.0f );
 		     pwm_set_reverse( i , 0.0f );
 		     }
-		     delay(100);
-		     GPIO_WriteBit(GPIOF, GPIO_PIN_1, Bit_SET); // bridge dir 1   
+		     delay(1000);
+		     GPIO_WriteBit(GPIOF, GPIO_PIN_1, Bit_SET); // bridge dir 1
 		     GPIO_WriteBit(GPIOA, GPIO_PIN_4, Bit_SET); // bridge dir 2
 		   */
 	  }

--- a/H101_dual/src/drv_pwm.c
+++ b/H101_dual/src/drv_pwm.c
@@ -456,7 +456,7 @@ void pwm_dir(int dir)
 		     pwm_set_forward( i , 0.0f );
 		     pwm_set_reverse( i , 0.0f );
 		     }
-		     delay(1000);
+		     delay(100);
 		     GPIO_WriteBit(GPIOF, GPIO_PIN_1, Bit_SET); // bridge dir 1
 		     GPIO_WriteBit(GPIOA, GPIO_PIN_4, Bit_SET); // bridge dir 2
 		   */

--- a/H101_dual/src/drv_pwm.c
+++ b/H101_dual/src/drv_pwm.c
@@ -426,7 +426,6 @@ void pwm_dir(int dir)
 		  for (int i = 0; i <= 3; i++)
 			  pwm_set_reverse(i, 0.0f);
 		  GPIO_WriteBit(GPIOA, GPIO_PIN_4, Bit_RESET);	// bridge dir 2
-		  delay(1000);
 		  GPIO_WriteBit(GPIOF, GPIO_PIN_1, Bit_SET);	// bridge dir 1
 
 	  }
@@ -437,7 +436,6 @@ void pwm_dir(int dir)
 		  for (int i = 0; i <= 3; i++)
 			  pwm_set_forward(i, 0.0f);
 		  GPIO_WriteBit(GPIOF, GPIO_PIN_1, Bit_RESET);	// bridge dir 1
-		  delay(1000);
 		  GPIO_WriteBit(GPIOA, GPIO_PIN_4, Bit_SET);	// bridge dir 2
 	  }
 	if (dir == FREE)


### PR DESCRIPTION
Commit 33444ff:

Before this change, the n-channel MOSFETs got a PWM signal also during the BRIDGE_WAIT stage. This would lead to a short in the bridge if pwm_dir(BRAKE) is used instead of pwm_dir(FREE) during BRIDGE_WAIT.

With this change, it is possible to use pwm_dir(BRAKE). I tested it on actual hardware, and it does work and is visible when using long BRIDGE_TIMEOUT intervals for testing. However, when using realistic BRIDGE_TIMEOUT intervals it makes no noticable difference, if BRAKE or FREE is used during BRIDGE_WAIT. I would even think that FREE is the better choice, because of several reasons:
- No noticable difference between BREAK and FREE.
- It is saver to have both MOSFETs closed.
- Shorting the motor to break with both p-channel MOSFETs could potentially put additional stress to the p-channel MOSFETs which are already the weak link compared to the n-channel MOSFETs due to their higher RDSon.

The proposed change in this pull request should IMO nevertheless be made, because it adds safety.

Commit a21e19c:

This commit first closes the p-MOSFET in line 428 before opening the other p-MOSFET in symmetry to line 439. Always close before opening seems more save. But the more important change is the addition of the delay() lines. I think, what killed my p-channel MOSFETs was not the addition of the adaptive bridge timeout feature, but simply performing fast tic-tocs I recently managed to accomplish.

To test this, I firmy held the controller board to sense the temperature of the MOSFETs of one motor. Then I perform fast throttle changes from full forward to full backward. After a few cycles the MOSFETs get noticable hot to the touch, and I am sure they would burn out if I would continue this.

I think, without the delay() there might be a short period of time, where both n- and p-channel MOSFETs are open effectively shorting the bridge. Even a very short time at each throttle reversal would be enough to get them considerable warm after a few fast throttle switches. My theory is, that even after setting the PWM to 0 with the pwm_set_reverse(i, 0) and pwm_set_forward(i, 0) calls, the current active PWM cycle runs to completion, and immediately opening the p-channel MOSFET in the following line without any delay will lead to a very brief short of the bridge. Not noticable in normal operation, but increasing the temperature of the MOSFETs on continuous fast throttle direction switching.

For 32 kHz PWM a short delay() would be sufficient, for 450 Hz it could take up to 0.5 ms. However, I did my "temperature sensing tests" while wildly switching throttle direction with delay(100) and delay(1000) and had the impression, that delay(1000) keept them even cooler. Maybe it's not only PWM-run-to-completion, but also that the p-channel MOSFETs take some time to close because they are probably switched off using some pull-ups (to be able to switch them with open-drain drivers of the MCU).

With this change in place, the MOSFETs barely get warm, also on fast throttle switches.

That being said, I think the adaptive bridge timeout feature is not worth it. If one sets the timeout to some value, it should not be changed by some heuristic motor model.
