### PR TITLE
Exchanged the use of BRIDGE_REVERSE and BRIDGE_FORWARD

### DIFF
--- a/H101_dual/src/control.c
+++ b/H101_dual/src/control.c
@@ -874,29 +874,7 @@ unsigned long bridgetime = 0;
 void bridge_sequencer(int dir)
 {
 
-	if (dir == DIR1 && bridge_stage != BRIDGE_FORWARD)
-	  {
-
-		  if (bridge_stage == BRIDGE_REVERSE)
-		    {
-			    bridge_stage = BRIDGE_WAIT;
-			    bridgetime = gettime();
-			    pwm_dir(FREE);
-		    }
-		  if (bridge_stage == BRIDGE_WAIT)
-		    {
-			    if (gettime() - bridgetime > BRIDGE_TIMEOUT)
-			      {
-				      // timeout has elapsed
-				      bridge_stage = BRIDGE_FORWARD;
-				      pwm_dir(DIR1);
-
-			      }
-
-		    }
-
-	  }
-	if (dir == DIR2 && bridge_stage != BRIDGE_REVERSE)
+	if (dir == REVERSE && bridge_stage != BRIDGE_REVERSE)
 	  {
 
 		  if (bridge_stage == BRIDGE_FORWARD)
@@ -907,11 +885,33 @@ void bridge_sequencer(int dir)
 		    }
 		  if (bridge_stage == BRIDGE_WAIT)
 		    {
-			    if (gettime() - bridgetime > BRIDGE_TIMEOUT)
+			    if (gettime() - bridgetime > bridge_timeout)
 			      {
 				      // timeout has elapsed
 				      bridge_stage = BRIDGE_REVERSE;
-				      pwm_dir(DIR2);
+				      pwm_dir(REVERSE);
+
+			      }
+
+		    }
+
+	  }
+	if (dir == FORWARD && bridge_stage != BRIDGE_FORWARD)
+	  {
+
+		  if (bridge_stage == BRIDGE_REVERSE)
+		    {
+			    bridge_stage = BRIDGE_WAIT;
+			    bridgetime = gettime();
+			    pwm_dir(FREE);
+		    }
+		  if (bridge_stage == BRIDGE_WAIT)
+		    {
+			    if (gettime() - bridgetime > bridge_timeout)
+			      {
+				      // timeout has elapsed
+				      bridge_stage = BRIDGE_FORWARD;
+				      pwm_dir(FORWARD);
 
 			      }
 

--- a/H101_dual/src/control.c
+++ b/H101_dual/src/control.c
@@ -885,7 +885,7 @@ void bridge_sequencer(int dir)
 		    }
 		  if (bridge_stage == BRIDGE_WAIT)
 		    {
-			    if (gettime() - bridgetime > bridge_timeout)
+			    if (gettime() - bridgetime > BRIDGE_TIMEOUT)
 			      {
 				      // timeout has elapsed
 				      bridge_stage = BRIDGE_REVERSE;
@@ -907,7 +907,7 @@ void bridge_sequencer(int dir)
 		    }
 		  if (bridge_stage == BRIDGE_WAIT)
 		    {
-			    if (gettime() - bridgetime > bridge_timeout)
+			    if (gettime() - bridgetime > BRIDGE_TIMEOUT)
 			      {
 				      // timeout has elapsed
 				      bridge_stage = BRIDGE_FORWARD;


### PR DESCRIPTION
I had a hard time finding out how the bridge sequencer actually could work. I knew what it should do, but from the code it seemed to me that the stages were mixed up. This proposed change does not change any functionality, but simple exchanges the use of BRIDGE_REVERSE and BRIDGE_FORWARD. The bridge_stage is now consistent with the actual bridge state (pwm_dir), which makes it much more readable. Feel free to ignore this cosmetic change :)
