### PR TITLE
Do not reset PID axis when changing PID term

### DIFF
--- a/H101_dual/src/pid.c
+++ b/H101_dual/src/pid.c
@@ -129,8 +129,6 @@ void pid_precalc()
 // The return value is used to blink the leds in main.c
 int next_pid_term()
 {
-	current_pid_axis = 0;
-	
 	switch (current_pid_term)
 	{
 		case 0:


### PR DESCRIPTION
The current code switches the PID axis back to Roll when changing the PID term. This makes no sense, because when I am tuning the yaw axis, and want to change from the P yaw term to the I yaw term, the axis is reset to Roll.