### PR TITLE
Consistent buzzer start sound

### DIFF
--- a/H101_dual/src/buzzer.c
+++ b/H101_dual/src/buzzer.c
@@ -68,7 +68,8 @@ void buzzer()
 				pulse_rate = 600000; // 3/5ths second
 
 			// start the buzzer if timeout has elapsed
-			if ( time - buzzertime > BUZZER_DELAY || lowbatt)
+			const unsigned long delta_time = time - buzzertime;
+			if ( delta_time > BUZZER_DELAY || lowbatt)
 			{
 				// initialize pin only after minimum 10 seconds from powerup
 				if ( !buzzer_init && time >  10e6)
@@ -81,7 +82,7 @@ void buzzer()
 
 
 				// enable buzzer
-				if (time%pulse_rate>pulse_rate/2)
+				if (delta_time % pulse_rate < pulse_rate / 2)
 				{
 					if ( toggle  ) // cycle the buzzer
 					{


### PR DESCRIPTION
This change improves two things:
1. Buzzing starts with a whole ON/OFF period instead of some random fraction.
2. Buzzing starts immediately when the condition is met instead of waiting half a period.