### PR TITLE
Carry forward the remainder ticks

### DIFF
--- a/H101_dual/src/drv_time.c
+++ b/H101_dual/src/drv_time.c
@@ -41,23 +41,27 @@ void time_init()
 	// NVIC_SetPriority(SysTick_IRQn, 0x00);     
 }
 
-// called at least once per second or time will overflow
-unsigned long time_update(void)
+// must be called at least once per second or time will overflow
+unsigned long time_update()
 {
-	unsigned long maxticks = SysTick->LOAD;
-	unsigned long ticks = SysTick->VAL;
+	const unsigned long maxticks = SysTick->LOAD;
+	const unsigned long ticks = SysTick->VAL;
 	unsigned long elapsedticks;
+	static unsigned long remainder = 0; // carry forward the remainder ticks;
 
-	if (ticks < lastticks)
+	if (ticks < lastticks) {
 		elapsedticks = lastticks - ticks;
-	else
-	  {	// overflow ( underflow really)
-		  elapsedticks = lastticks + (maxticks - ticks);
-	  }
+	} else { // overflow ( underflow really)
+		elapsedticks = lastticks + (maxticks - ticks);
+	}
 
 	lastticks = ticks;
+	elapsedticks += remainder;
 
-	globalticks = globalticks + elapsedticks / 6;
+	const unsigned long quotient = elapsedticks / 6;
+	remainder = elapsedticks - quotient * 6;
+
+	globalticks += quotient;
 	return globalticks;
 }
 


### PR DESCRIPTION
Carry over the remainder ticks which were previously lost, which resulted in inaccurate time keeping.

Proposed by bikemikem in https://www.rcgroups.com/forums/showthread.php?2876797-Boldclash-bwhoop-B-03-opensource-firmware/page64#post38394278 and implemented in his repository here https://github.com/bikemike/BoldClash-BWHOOP-B-03/blob/4way/Silverware/src/drv_time.c

I didn't include his fast divide optimization, because reducing the function runtime from 3µs to 1µs is IMO no significant benefit, but would require calling the function at least every 16ms.