### PR TITLE
Remove the 10 µs looptime jitter.

### DIFF
--- a/H101_dual/src/main.c
+++ b/H101_dual/src/main.c
@@ -480,8 +480,8 @@ if( thrfilt > 0.1f )
 
 					
 	// loop time 1ms                
-	while ((gettime() - maintime) < (1000 - 22) )
-			delay(10);
+	while ( gettime() - maintime < 1000 - 1 )
+	{}
 
 
 


### PR DESCRIPTION
Depending on when the busy-waiting loop at the end is reached, due to its 10 µs granularity a looptime jitter is introduced.
Removing the unnecessary delay granularity fixes this.