### PR TITLE
Added RX_SMOOTHING option

### DIFF
--- a/H101_dual/src/config.h
+++ b/H101_dual/src/config.h
@@ -284,16 +284,18 @@
 #define PID_GESTURE_TUNING
 #define COMBINE_PITCH_ROLL_PID_TUNING
 
-// Rotate I-term vector for a stable yaw axis
+// Rotate I-term vector for a stable yaw axis (aka iTerm Rotation)
 #define PID_ROTATE_ERRORS
 
-// Removes roll and pitch bounce back after flips
+// Removes roll and pitch bounce back after flips (aka iTerm Relax)
 #define TRANSIENT_WINDUP_PROTECTION
 
 // Feed fast roll/pitch-stick changes directly to the motors to give a snappier response
 // 0.0f (or commented out) equates D-term on measurement, 1.0f equates D-term on error.
 //#define FEED_FORWARD_STRENGTH 1.0f
 
+// Add linear interpolation between the otherwise 5 ms staircase steps of the RX signal
+//#define RX_SMOOTHING
 
 // ########################################
 // things that are experimental / old / etc

--- a/H101_dual/src/pid.c
+++ b/H101_dual/src/pid.c
@@ -337,6 +337,12 @@ float pid(int x)
 // https://www.rcgroups.com/forums/showpost.php?p=39667667&postcount=13956
 #ifdef FEED_FORWARD_STRENGTH
 	if ( x < 2 ) {
+
+#ifdef RX_SMOOTHING
+		static float lastSetpoint[2];
+		float ff = ( setpoint[x] - lastSetpoint[x] ) * timefactor * FEED_FORWARD_STRENGTH * pidkd[x];
+		lastSetpoint[x] = setpoint[x];
+#else
 		static float lastSetpoint[2];
 		static float setpointDiff[2];
 		static int ffCount[2];
@@ -351,6 +357,7 @@ float pid(int x)
 			--ffCount[x];
 			ff = setpointDiff[x] * timefactor * FEED_FORWARD_STRENGTH * pidkd[x];
 		}
+#endif
 
 		// 8 point moving average filter to smooth out the 5 ms steps:
 		#define MA_SIZE ( 1 << 3 ) // power of two


### PR DESCRIPTION
With no motor filtering, setpoint changes (i.e. stick movements) get directly applied to the motors. Since new rx data arrives only every 5 ms (bayang with telemetry), this leads to a staircase signal.

This is especially bad on setpoint derivative or if THROTTLE_TRANSIENT_COMPENSATION is enabled which leads to a throttle spike every 5 ms during throttle stick movement.

(FEED_FORWARD already handles this by spreading the setpoint diff across 5 loop cycles and even does its own moving average filtering afterwards.)

To mitigate this behaviour I added RX_SMOOTHING as an option. This interpolates the RX signal linearly between two steps, making also the FEED_FORWARD spreading unnecessary when activated.