### PR TITLE
Added a hold-off time to the throttle HPF when reversing the motors.

### DIFF
--- a/H101_dual/src/control.c
+++ b/H101_dual/src/control.c
@@ -37,6 +37,7 @@ THE SOFTWARE.
 
 
 extern float throttlehpf(float in);
+extern void throttlehpf_reset(void);
 
 extern int ledcommand;
 extern float rx[4];
@@ -1106,6 +1107,7 @@ void bridge_sequencer(int dir)
 			    pwm_dir(FREE);
 			    extern float ierror[3];
 			    ierror[0] = 0.0; ierror[1] = 0.0; ierror[2] = 0.0;
+			    throttlehpf_reset();
 		    }
 		  if (bridge_stage == BRIDGE_WAIT)
 		    {
@@ -1130,6 +1132,7 @@ void bridge_sequencer(int dir)
 			    pwm_dir(FREE);
 			    extern float ierror[3];
 			    ierror[0] = 0.0; ierror[1] = 0.0; ierror[2] = 0.0;
+			    throttlehpf_reset();
 		    }
 		  if (bridge_stage == BRIDGE_WAIT)
 		    {

--- a/H101_dual/src/filter.cpp
+++ b/H101_dual/src/filter.cpp
@@ -375,18 +375,28 @@ class  FilterBeHp1
 	public:
 		FilterBeHp1()
 		{
-			v[0]=0.0;
+			reset();
 		}
 	private:
 		float v[2];
+		int holdoff;
 	public:
 		float step(float x) //class II
 		{
 			v[0] = v[1];
 			v[1] = (9.521017968695103528e-1f * x)
 				 + (0.90420359373902081668f * v[0]);
+			if ( holdoff > 0 ) {
+				--holdoff;
+				return 0.0;
+			}
 			return
 				 (v[1] - v[0]);
+		}
+		void reset()
+		{
+			v[0] = v[1]	= 0.0;
+			holdoff = 200; // ms
 		}
 };
 
@@ -397,6 +407,10 @@ extern "C" float throttlehpf( float in )
 	return throttlehpf1.step(in );
 }
 
+extern "C" void throttlehpf_reset()
+{
+	throttlehpf1.reset();
+}
 
 
 //Low pass bessel filter order=1 alpha1=0.023


### PR DESCRIPTION
For some relaxing 3S 5" quad I tried THROTTLE_TRANSIENT_COMPENSATION again. I noticed that motor reversing for 3D was a lot more jerky with the throttle HPF enabled. Sometimes I even had bad desyncs.

Therefore I added some holdoff time for the HPF which gets triggered when the motors reverse, to give the motors some time to gracefully reverse.